### PR TITLE
FCM 메시지 포맷 수정

### DIFF
--- a/src/main/java/com/rtsj/return_to_soju/controller/MLController.java
+++ b/src/main/java/com/rtsj/return_to_soju/controller/MLController.java
@@ -28,16 +28,34 @@ public class MLController {
     private final MLService mlService;
     private final UserService userService;
     private final FirebaseCloudMessageService firebaseCloudMessageService;
+
     @Operation(summary = "ML 분석 후 카톡 데이터 받아오기", description = "ML서버가 카톡 데이터 처리를 마친 후 해당 api를 호출하여 데이터를 저장한다.")
     @PostMapping("/ml/kakao")
     public ResponseEntity<SuccessResponseResult> saveKakaoMLData(@RequestBody KakaoMLDataSaveRequestDto dto) throws IOException {
         mlService.saveKakaoMLData(dto);
         String userFcmToken = userService.getUserFcmToken(dto.getUser_pk());
-        String start_date = dto.getStart_date();
-        String end_date = dto.getEnd_date();
-        firebaseCloudMessageService.sendAnalyzeMessageTo(userFcmToken, "몽글몽글", "분석이 완료됐어요~!", start_date + "-" + end_date);
+        String start_date = prettierDateString(dto.getStart_date());
+        String end_date = prettierDateString(dto.getEnd_date());
+        firebaseCloudMessageService.sendAnalyzeMessageTo(userFcmToken, "몽글몽글", "분석이 완료됐어요~!", start_date + " ~ " + end_date);
         return ResponseEntity.ok()
                 .body(new SuccessResponseResult("성공"));
+    }
+
+    /**
+     * Date Text를 형식에 맞춰 포장. ex) 20220101 -> 2022.01.01 <br/>
+     * <b>예외 처리</b> <br/>
+     * YYYYMMDD 형식인 경우에만 formatting하기 위해 text의 길이가 8인 경우에만 포장한다. 그 외에는 dateText그대로 반환.
+     * YYYYMMDD인지까지는 확인하지 않음. 길이가 8이면 무조건 YYYYMMDD라고 가정 (for better performance / simpler)
+     */
+    private String prettierDateString(String dateText) {
+        if (dateText.length() != 8) {
+            return dateText;
+        }
+        return String.format("%s.%s.%s",
+                dateText.substring(0, 4), // YYYY
+                dateText.substring(4, 6), // MM
+                dateText.substring(6) // DD
+        );
     }
 
 
@@ -45,7 +63,7 @@ public class MLController {
     @PostMapping("/ml/error")
     public ResponseEntity<SuccessResponseResult> saveKakaoMLError(@RequestBody KakaoMLErrorRequestDto dto) throws IOException {
         String userFcmToken = userService.getUserFcmToken(dto.getUser_pk());
-        firebaseCloudMessageService.sendErrorMessageTo(userFcmToken,"몽글몽글", "파일 업로드에 실패했어요:(");
+        firebaseCloudMessageService.sendErrorMessageTo(userFcmToken, "몽글몽글", "파일 업로드에 실패했어요:(");
         return ResponseEntity.ok()
                 .body(new SuccessResponseResult("Error 메세지 전송"));
     }

--- a/src/main/java/com/rtsj/return_to_soju/model/dto/dto/FcmMessage.java
+++ b/src/main/java/com/rtsj/return_to_soju/model/dto/dto/FcmMessage.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class FcmMessage {
-
     private boolean validate_only;
     private Message message;
 
@@ -16,17 +15,7 @@ public class FcmMessage {
     @AllArgsConstructor
     @Getter
     public static class Message{
-        private Notification notification; //mobile os
         private String token; //특정 디바이스 보내는 경우
         private FcmTypeAndData data;
-    }
-
-    @Builder
-    @AllArgsConstructor
-    @Getter
-    public static class Notification{
-        private String title;
-        private String body;
-        private String image;
     }
 }

--- a/src/main/java/com/rtsj/return_to_soju/model/dto/dto/FcmTypeAndData.java
+++ b/src/main/java/com/rtsj/return_to_soju/model/dto/dto/FcmTypeAndData.java
@@ -1,11 +1,37 @@
 package com.rtsj.return_to_soju.model.dto.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
-@AllArgsConstructor
 public class FcmTypeAndData {
+    private String title;
+    private String body;
     private String type;
     private String data;
+
+    /**
+     * 메시지 모드. 데이터 없이 메시지만 보내는 경우 사용한다.
+     *
+     * @param title 제목
+     * @param body  내용
+     */
+    public FcmTypeAndData(String title, String body) {
+        this.title = title;
+        this.body = body;
+    }
+
+    /**
+     * 데이터 모드. 메시지와 함께 데이터를 보내는 경우 사용한다.
+     *
+     * @param title 제목
+     * @param body  내용
+     * @param type  데이터 타입 (error | analyze | gift)
+     * @param data  데이터 payload
+     */
+    public FcmTypeAndData(String title, String body, String type, String data) {
+        this.title = title;
+        this.body = body;
+        this.type = type;
+        this.data = data;
+    }
 }

--- a/src/main/java/com/rtsj/return_to_soju/service/FirebaseCloudMessageService.java
+++ b/src/main/java/com/rtsj/return_to_soju/service/FirebaseCloudMessageService.java
@@ -104,13 +104,7 @@ public class FirebaseCloudMessageService{
         FcmMessage fcmMessage = FcmMessage.builder()
                 .message(FcmMessage.Message.builder()
                         .token(targetToken)
-                        .notification(
-                                FcmMessage.Notification.builder()
-                                .title(title)
-                                .body(body)
-                                .image(null)
-                                .build()
-                        )
+                        .data(new FcmTypeAndData(title, body))
                         .build()
                 )
                 .validate_only(false)
@@ -121,14 +115,7 @@ public class FirebaseCloudMessageService{
         FcmMessage fcmMessage = FcmMessage.builder()
                 .message(FcmMessage.Message.builder()
                         .token(targetToken)
-                        .notification(
-                                FcmMessage.Notification.builder()
-                                        .title(title)
-                                        .body(body)
-                                        .image(null)
-                                        .build()
-                        )
-                        .data(new FcmTypeAndData("error","전송 실패"))
+                        .data(new FcmTypeAndData(title, body, "error", "전송 실패"))
                         .build()
                 )
                 .validate_only(false)
@@ -139,14 +126,7 @@ public class FirebaseCloudMessageService{
         FcmMessage fcmMessage = FcmMessage.builder()
                 .message(FcmMessage.Message.builder()
                         .token(targetToken)
-                        .notification(
-                                FcmMessage.Notification.builder()
-                                        .title(title)
-                                        .body(body)
-                                        .image(null)
-                                        .build()
-                        )
-                        .data(new FcmTypeAndData("analyze",date))
+                        .data(new FcmTypeAndData(title, body, "analyze", date))
                         .build()
                 )
                 .validate_only(false)
@@ -157,7 +137,7 @@ public class FirebaseCloudMessageService{
 
 
     private String getAccessToken() throws IOException{
-        String firebaseConfigPath = "firebase/"+keyName;
+        String firebaseConfigPath = "firebase/" +keyName;
         GoogleCredentials googleCredentials = GoogleCredentials
                 .fromStream(new ClassPathResource(firebaseConfigPath)
                         .getInputStream())
@@ -168,7 +148,7 @@ public class FirebaseCloudMessageService{
 
     @PostConstruct
     public void init(){
-        String firebaseConfigPath = "firebase/"+keyName;
+        String firebaseConfigPath = "firebase/" +keyName;
         try{
             FirebaseOptions options = new FirebaseOptions.Builder()
                     .setCredentials(


### PR DESCRIPTION
### 배경
FCM 메시지 종류
 - **알림 메시지**: 사용자에게 알림만 주는 메시지. FCM Request message에 **notification만** 지정된 경우 알림 메시지로 분류된다. 이 경우에는 메시지가 **Android System**에서 처리된다.
 - **데이터 메시지**: 사용자에게 데이터를 보내는 메시지. FCM Request message에 **data만** 지정된 경우 알림 메시지로 분류된다. 이 경우에는 메시지가 **App Service**(몽글몽글)에서 처리된다.
 - **선택적 데이터 메시지**: 알림 및 데이터 메시지를 같이 보냄. FCM Request message에 **notification과 data 모두** 지정된 경우 알림 메시지로 분류된다. 이 경우에는 앱이 **foreground에 있을 경우 Android System**에서, **background에 있을 경우 App Service**에서 처리한다.

[Google 메시지 유형 참고](https://firebase.google.com/docs/cloud-messaging/concept-options?hl=ko#notifications)

### FCM 메시지 포맷을 수정한 이유?
기존에는 **선택적 데이터 메시지** 포맷으로 주고받았습니다. 그런데 최근에 앱을 테스트해보니 앱이 꺼져있거나 background에 있을 때, **분석 완료 알림을 눌러도 Dialog가 안뜨는 버그**가 발생했습니다.

원인은 선택적 데이터 메시지 포맷으로 주고받았기 때문입니다.
 - **앱이 foreground** -> 우리가 구현한 App Service에서 메시지를 처리
 - **앱이 꺼져있거나 background** -> Android System에서 처리

그래서 우리가 구현한 동작이 아니라, Android System의 Default Notification Action에 따라 Dialog를 안 띄우고 그냥 앱을 실행합니다.

### Q&A
#### 1. 그럼 어떤 포맷으로 보내야 하는지?
**데이터 메시지**로 보내야합니다. 그래야 앱이 어떤 상태든 App Service에서 메시지를 처리할 수 있기 때문입니다.

#### 2. 포맷을 어떻게 보내야하는지?
기존에는 notification, data필드 2개를 같이 보냈습니다. 그렇게 말고 notification 필드를 지우고, data 필드만 남겨서 보내면 됩니다.

#### 3. 그러면 메시지 title과 body는?
data에 payload들과 함께 동봉해서 보냅니다. 즉, data필드에 title, body, type, data(payload) 이렇게 4개를 포함시켜서 보내야합니다.


### 수정사항 요약
#### FCM DTO 변경
기존 (일부 생략)
```json
"message": {
  "notification": {
    "title": "알림 제목",
    "body": "알림 내용"
  },
  "data": {
    "type": "데이터 타입",
    "data": "데이터 payload"
  }
}
```
변경 (일부 생략)
```json
"message": {
  "data": {
    "title": "알림 제목",
    "body": "알림 내용",
    "type": "데이터 타입",
    "data": "데이터 payload"
  }
}
```
#### Analyzed Complete Message에 포함된 data를 좀 더 깔끔하게 수정
20220101-20220202 -> 2022.01.01 ~ 2022.02.02