### PR TITLE
Fix: CalendarUtil.getMonthEndDay 수정

### DIFF
--- a/src/main/java/com/rtsj/return_to_soju/common/CalendarUtil.java
+++ b/src/main/java/com/rtsj/return_to_soju/common/CalendarUtil.java
@@ -23,6 +23,7 @@ public class CalendarUtil {
         Calendar cal = Calendar.getInstance();
         cal.set(Calendar.YEAR, year);
         cal.set(Calendar.MONTH, month - 1);
+        cal.set(Calendar.DAY_OF_MONTH, 1);
         return cal.getActualMaximum(Calendar.DAY_OF_MONTH);
     }
 


### PR DESCRIPTION
Calendar 구현체에서 날짜(일)을 세팅하지 않았더니 요청을 보내는 날로 자동 세팅됨
-> 10/31일에 2월을 요청하면 2022-02-31 으로 되어 2022-03-02로 넘어감 
-> 1일로 강제 세팅함으로서 해결