### PR TITLE
Feat: 카카오 회원탈퇴

### DIFF
--- a/src/main/java/com/rtsj/return_to_soju/repository/UserRepository.java
+++ b/src/main/java/com/rtsj/return_to_soju/repository/UserRepository.java
@@ -22,4 +22,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
             "and calender.emotion ='HAPPY' " +
             "order by Rand() LIMIT 1;", nativeQuery = true)
     LocalDate findMemoryByFcmToken(@Param("token")String token);
+
+    void deleteById(Long userId);
 }

--- a/src/main/java/com/rtsj/return_to_soju/service/CalenderService.java
+++ b/src/main/java/com/rtsj/return_to_soju/service/CalenderService.java
@@ -88,7 +88,7 @@ public class CalenderService {
                 .build();
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("sentence", data.getText());
-        jsonObject.put("key", data.getKey());
+//        jsonObject.put("key", data.getKey());
         RequestBody requestBody = RequestBody.create(jsonObject.toString(), MediaType.get("application/json; charset=utf-8"));
         Request request = new Request.Builder()
                 .url(chatbotURL)
@@ -100,9 +100,12 @@ public class CalenderService {
         JSONObject parse = (JSONObject) jsonParser.parse(string);
 
         String answer = parse.get("answer").toString();
-        String encrypt = parse.get("encrypt").toString();
+        /**
+         * todo : App Update되면 올리 것.
+         */
+//        String encrypt = parse.get("encrypt").toString();
 
-        return new MLChatbotDto(answer, encrypt);
+        return new MLChatbotDto(answer, data.getText());
     }
 
 

--- a/src/main/java/com/rtsj/return_to_soju/service/OauthService.java
+++ b/src/main/java/com/rtsj/return_to_soju/service/OauthService.java
@@ -68,6 +68,7 @@ public class OauthService {
 
 
     private KakaoRenewInfo getRenewKakaoToken(String kakaoRefreshToken){
+        log.info("카카오톡 재발급");
         Map<String, Object> kakaoRenewResponse = getKakaoRenewResponse(kakaoRefreshToken);
         KakaoRenewInfo kakaoRenewInfo = new KakaoRenewInfo(kakaoRenewResponse);
         return kakaoRenewInfo;
@@ -100,6 +101,7 @@ public class OauthService {
         KakaoRenewInfo renewKakaoToken = getRenewKakaoToken(user.getKakaoRefreshToken());
         String accessToken = renewKakaoToken.getAccessToken();
         Map<String, Object> stringObjectMap = unlinkUserRequest(accessToken);
+        log.info("카카오톡 회원 탈퇴");
         return stringObjectMap.get("id").toString();
     }
 

--- a/src/main/java/com/rtsj/return_to_soju/service/OauthService.java
+++ b/src/main/java/com/rtsj/return_to_soju/service/OauthService.java
@@ -96,8 +96,24 @@ public class OauthService {
         log.info(formData.toString());
         return formData;
     }
+    public String unlinkUser(User user) {
+        KakaoRenewInfo renewKakaoToken = getRenewKakaoToken(user.getKakaoRefreshToken());
+        String accessToken = renewKakaoToken.getAccessToken();
+        Map<String, Object> stringObjectMap = unlinkUserRequest(accessToken);
+        return stringObjectMap.get("id").toString();
+    }
 
-
-
+    private Map<String, Object> unlinkUserRequest(String accessToken) {
+        return WebClient.create()
+                .post()
+                .uri("https://kapi.kakao.com/v1/user/unlink")
+                .headers(httpHeaders -> {
+                    httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                    httpHeaders.setBearerAuth(accessToken);
+                })
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .block();
+    }
 }
 

--- a/src/main/java/com/rtsj/return_to_soju/service/UserService.java
+++ b/src/main/java/com/rtsj/return_to_soju/service/UserService.java
@@ -106,8 +106,8 @@ public class UserService {
     @Transactional
     public void deleteUser(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(NotFoundUserException::new);
-        userRepository.delete(user);
-        return;
+        String s = oauthService.unlinkUser(user);
+        userRepository.deleteById(Long.parseLong(s));
     }
 
 }

--- a/src/main/java/com/rtsj/return_to_soju/service/UserService.java
+++ b/src/main/java/com/rtsj/return_to_soju/service/UserService.java
@@ -110,4 +110,5 @@ public class UserService {
         userRepository.deleteById(Long.parseLong(s));
     }
 
+
 }


### PR DESCRIPTION
카카오 회원탈퇴 요청시, 카카오 리프레쉬 토큰으로 해당 유저의 Access토큰을 재발급 한 뒤, Unlink로직을 수행한다.